### PR TITLE
Support for Mixpanel properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ Configure the `mixpanel` redux middleware by invoking with an options object, co
 2. `blacklist` – An optional array of blacklisted action types.
 3. `selectDistinctId` – A selector function that returns the `distinct_id` (user id), given the action and store state.
 4. `selectUserProfileData` – A selector function that returns user profile data for a Mixpanel Engage request, given the action and store state.
+5. `selectProperties` - An optional selector function that returns Mixpanel properties to add to the request, given the action and store state.

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 import trackEvent from './api/trackEvent'
 import updateUserProfile from './api/updateUserProfile'
 
-export default mixpanel = ({ token, selectDistinctId = ()=>null, selectUserProfileData = ()=>null, blacklist = [] }) => store => next => action => {
+export default mixpanel = ({
+  token,
+  selectDistinctId = () => null,
+  selectUserProfileData = () => null,
+  selectProperties = () => null,
+  blacklist = []
+}) => store => next => action => {
   // Don't track if action type is in blacklist or is falsey
   const actionIsBlacklisted = blacklist.indexOf(action.type) >= 0
   if (actionIsBlacklisted || !action.type) {
@@ -11,12 +17,14 @@ export default mixpanel = ({ token, selectDistinctId = ()=>null, selectUserProfi
   // Get store state; select distinct id for action & state
   const state = store.getState()
   const distinctId = selectDistinctId(action, state)
-  
+  const properties = selectProperties(action, state)
+
   // Track action event with Mixpanel
   trackEvent({
     token,
     distinctId,
     eventName: action.type,
+    eventData: properties
   })
 
   // Select user profile data for action; if it selects truthy data,


### PR DESCRIPTION
Adds support for optionally including whatever properties you like to the Mixpanel tracking request. 

This should work,  but is unfortunately difficult to test since I'm having trouble transpiling this library with my webpack config. I would suggest adding a build step and distributing plain ES5 ;) My guess is most people don't transpile node_modules. 

I would help but in my case it took quite a few changes for it to work so I don't think you would want that.
