### PR TITLE
Track IP address

### DIFF
--- a/src/api/sendMixpanelRequest.js
+++ b/src/api/sendMixpanelRequest.js
@@ -12,7 +12,7 @@ export default sendMixpanelRequest = ({ endpoint, data }) => {
   const requestDataString = JSON.stringify(data)
   const requestDataBase64String = new Buffer(requestDataString).toString('base64')
 
-  const requestUrl = `${MIXPANEL_REQUEST_PROTOCOL}://${MIXPANEL_HOST}${endpoint}`
+  const requestUrl = `${MIXPANEL_REQUEST_PROTOCOL}://${MIXPANEL_HOST}${endpoint}?ip=1`
   const req = request
     .get(requestUrl)
     .query(`data=${requestDataBase64String}`)


### PR DESCRIPTION
We need to add ip=1 as a URL parameter according to Mixpanel docs in order to track the IP address of the request (which is used for geo lookup of the user).
