### PR TITLE
add an optional selectEventName function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install --save rn-redux-mixpanel
 // store/index.js
 import mixpanel from 'rn-redux-mixpanel'
 import { INIT_PERSISTENCE, HYDRATE, SESSION_ACTIVITY, SIGN_IN } from '../../constants/ActionTypes'
+import humanize from 'underscore.string'
 
 // Export configured mixpanel redux middleware
 export default mixpanel({
@@ -26,6 +27,9 @@ export default mixpanel({
 
   // Mixpanel Token
   token: YOUR_MIXPANEL_TOKEN,
+
+  // derive Mixpanel event name from action and/or state
+  selectEventName: (action, state) => humanize(action.type),
 
   // Per-action selector: Mixpanel event `distinct_id`
   selectDistinctId: (action, state) => {
@@ -64,4 +68,5 @@ Configure the `mixpanel` redux middleware by invoking with an options object, co
 2. `blacklist` – An optional array of blacklisted action types.
 3. `selectDistinctId` – A selector function that returns the `distinct_id` (user id), given the action and store state.
 4. `selectUserProfileData` – A selector function that returns user profile data for a Mixpanel Engage request, given the action and store state.
-5. `selectProperties` - An optional selector function that returns Mixpanel properties to add to the request, given the action and store state.
+5. `selectEventName` – A optional selector function that returns the Mixpanel event name, given the action and store state. By default action.type.
+6. `selectProperties` - An optional selector function that returns Mixpanel properties to add to the request, given the action and store state.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export default mixpanel = ({
   token,
   selectDistinctId = () => null,
   selectUserProfileData = () => null,
+  selectEventName = (action) => action.type, 
   selectProperties = () => null,
   blacklist = []
 }) => store => next => action => {
@@ -17,13 +18,14 @@ export default mixpanel = ({
   // Get store state; select distinct id for action & state
   const state = store.getState()
   const distinctId = selectDistinctId(action, state)
+  const eventName = selectEventName(action, state)
   const properties = selectProperties(action, state)
 
   // Track action event with Mixpanel
   trackEvent({
     token,
     distinctId,
-    eventName: action.type,
+    eventName: eventName,
     eventData: properties
   })
 


### PR DESCRIPTION
This gives the possibility to translate action types to mixpanel events.
By default, the action.type is used.
