### PR TITLE
always use HTTPS for tracking

### DIFF
--- a/src/api/sendMixpanelRequest.js
+++ b/src/api/sendMixpanelRequest.js
@@ -5,7 +5,7 @@ import request from 'superagent'
 const DEBUG = typeof process === 'object' && process.env && process.env['NODE_ENV'] === 'development'
 
 // Mixpanel Service Constants
-const MIXPANEL_REQUEST_PROTOCOL = 'http'
+const MIXPANEL_REQUEST_PROTOCOL = 'https'
 const MIXPANEL_HOST = 'api.mixpanel.com'
 
 export default sendMixpanelRequest = ({ endpoint, data }) => {


### PR DESCRIPTION
Hello @danscan,
I don't see any reason not to use HTTPS when talking to the Mixpanel API, so let us use it always :)

Cheers
