### PR TITLE
Use named functions instead of anonymous functions

### DIFF
--- a/src/api/sendMixpanelRequest.js
+++ b/src/api/sendMixpanelRequest.js
@@ -8,7 +8,7 @@ const DEBUG = typeof process === 'object' && process.env && process.env['NODE_EN
 const MIXPANEL_REQUEST_PROTOCOL = 'https'
 const MIXPANEL_HOST = 'api.mixpanel.com'
 
-export default sendMixpanelRequest = ({ endpoint, data }) => {
+export default function sendMixpanelRequest ({ endpoint, data }) {
   const requestDataString = JSON.stringify(data)
   const requestDataBase64String = new Buffer(requestDataString).toString('base64')
 

--- a/src/api/trackEvent.js
+++ b/src/api/trackEvent.js
@@ -3,7 +3,7 @@ import sendMixpanelRequest from './sendMixpanelRequest'
 // Configuration Constants
 const MIXPANEL_TRACK_ENDPOINT = '/track'
 
-export default trackEvent = ({ token, eventName, distinctId, eventData = {} }) => {
+export default function trackEvent ({ token, eventName, distinctId, eventData = {} }) {
   // Build event properties
   const eventProperties = {
     token,

--- a/src/api/updateUserProfile.js
+++ b/src/api/updateUserProfile.js
@@ -3,7 +3,7 @@ import sendMixpanelRequest from './sendMixpanelRequest'
 // Configuration Constants
 const MIXPANEL_ENGAGE_ENDPOINT = '/engage'
 
-export default updateUserProfile = ({ token, distinctId, userProfileData }) => {
+export default function updateUserProfile ({ token, distinctId, userProfileData }) {
   // Build request data for engage request
   const engageRequestData = {
     '$token': token,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import trackEvent from './api/trackEvent'
 import updateUserProfile from './api/updateUserProfile'
 
-export default mixpanel = ({
+export default function mixpanel({
   token,
   selectDistinctId = () => null,
   selectUserProfileData = () => null,


### PR DESCRIPTION
ES6 default exports are a bit weird.  You can't initialize variables in a onliner like the current implementation which uses anonymous functions.  But if you remove the variable name you lose the awesome stacktrace.  Initializing the function as a constant just adds too much boilerplate.

Named functions seem to be the best compromise outside of using a babel transformation like [babel-plugin-transform-export-default-name](https://github.com/gajus/babel-plugin-transform-export-default-name) which is overkill for a library.
